### PR TITLE
Use dependency-groups instead of project.optional-dependencies for local dev-deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
           enable-cache: true
 
       - name: Install deps
-        run: uv sync --all-extras
+        run: uv sync
 
       - uses: pre-commit/action@v3.0.1
         env:
@@ -67,7 +67,7 @@ jobs:
         run: uv python pin "${{ matrix.python-version }}"
 
       - name: Install deps
-        run: uv sync --all-extras
+        run: uv sync
 
       - name: Install Django
         run: uv pip install Django=="${{ matrix.django-version }}.*"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,7 +4,8 @@ on:
   push:
     tags: [v*]
 
-permissions: read-all
+env:
+  UV_FROZEN: 1
 
 jobs:
   build-docs:
@@ -21,7 +22,7 @@ jobs:
           enable-cache: true
 
       - name: Install deps
-        run: uv sync --frozen --all-extras
+        run: uv sync
 
       - name: Generate API docs
         run: make docs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,8 @@ on:
   push:
     tags: [v*]
 
-permissions: read-all
+env:
+  UV_FROZEN: 1
 
 jobs:
   release:
@@ -23,7 +24,7 @@ jobs:
           enable-cache: true
 
       - name: Install deps
-        run: uv sync --frozen --all-extras
+        run: uv sync
 
       - name: Build package
         run: uv build

--- a/examples/todo/Makefile
+++ b/examples/todo/Makefile
@@ -19,7 +19,7 @@ help: Makefile  ## Show help
 # =============================================================================
 install:  ## Install deps
 	uv python install
-	uv sync --frozen --all-extras
+	uv sync --frozen
 .PHONY: install
 
 run:  ## Run development server

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,9 +21,6 @@ def tests(
     *,
     extras: list[str],
 ) -> None:
-    # Test dependencies are required and always installed
-    extras.extend(["dev", "test"])
-
     # Run the tests via `uv`
     session.run_install("uv", "sync", "--quiet", *[f"--extra={extra}" for extra in extras])
     session.run("uv", "run", "pytest", "--cov-append")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,16 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.9, <4.0"
 dependencies = [
-    "django>=4.2,<5.2",
-    "slack-bolt>=1,<2",
-    "xmltodict>=0.14.1,<1",
-	"pydantic>=2,<3"
+	"django>=4.2,<5.2",
+	"slack-bolt>=1,<2",
+	"xmltodict>=0.14.1,<1",
+	"pydantic>=2,<3",
 ]
 
 [project.optional-dependencies]
 celery = ["celery>=5,<6"]
+
+[dependency-groups]
 dev = [
 	"django-debug-toolbar>=4.4,<6.0",
 	"django-extensions>=3.2,<5.0",
@@ -36,7 +38,7 @@ test = [
 	"pytest-sugar~=1.0",
 	"pytest-xdist~=3.6",
 	"pytest~=8.0",
-    "nox>=2024.10.9,<2025.3.0",
+	"nox>=2024.10.9,<2025.3.0",
 ]
 
 [project.urls]
@@ -50,6 +52,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["django_slack_tools"]
+
+[tool.uv]
+default-groups = ["dev", "test"]
 
 [tool.ruff]
 target-version = "py39"
@@ -99,7 +104,7 @@ addopts = [
 	"--cov-report=xml",
 	"--show-capture=no",
 	"--junitxml=junit.xml",
-	"-rs"
+	"-rs",
 ]
 testpaths = ["tests"]
 markers = ["slack: Tests working with Slack."]

--- a/uv.lock
+++ b/uv.lock
@@ -589,6 +589,8 @@ dependencies = [
 celery = [
     { name = "celery" },
 ]
+
+[package.dev-dependencies]
 dev = [
     { name = "django-debug-toolbar" },
     { name = "django-extensions" },
@@ -616,31 +618,37 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "celery", marker = "extra == 'celery'", specifier = ">=5,<6" },
-    { name = "coverage", marker = "extra == 'test'", specifier = "~=7.3" },
     { name = "django", specifier = ">=4.2,<5.2" },
-    { name = "django-coverage-plugin", marker = "extra == 'test'", specifier = "~=3.1" },
-    { name = "django-debug-toolbar", marker = "extra == 'dev'", specifier = ">=4.4,<6.0" },
-    { name = "django-extensions", marker = "extra == 'dev'", specifier = ">=3.2,<5.0" },
-    { name = "django-stubs", extras = ["compatible-mypy"], marker = "extra == 'dev'", specifier = "~=5.1" },
-    { name = "factory-boy", marker = "extra == 'test'", specifier = "~=3.3" },
-    { name = "faker", marker = "extra == 'test'", specifier = ">=30.3,<37.0" },
-    { name = "ipykernel", marker = "extra == 'dev'", specifier = "~=6.27" },
-    { name = "mkdocs", marker = "extra == 'dev'", specifier = "~=1.6" },
-    { name = "mkdocs-material", marker = "extra == 'dev'", specifier = "~=9.5" },
-    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = "~=0.26" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = "~=1.11" },
-    { name = "nox", marker = "extra == 'test'", specifier = ">=2024.10.9,<2025.3.0" },
     { name = "pydantic", specifier = ">=2,<3" },
-    { name = "pytest", marker = "extra == 'test'", specifier = "~=8.0" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5,<7" },
-    { name = "pytest-django", marker = "extra == 'test'", specifier = "~=4.9" },
-    { name = "pytest-sugar", marker = "extra == 'test'", specifier = "~=1.0" },
-    { name = "pytest-xdist", marker = "extra == 'test'", specifier = "~=3.6" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "~=0.6" },
     { name = "slack-bolt", specifier = ">=1,<2" },
     { name = "xmltodict", specifier = ">=0.14.1,<1" },
 ]
-provides-extras = ["celery", "dev", "test"]
+provides-extras = ["celery"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "django-debug-toolbar", specifier = ">=4.4,<6.0" },
+    { name = "django-extensions", specifier = ">=3.2,<5.0" },
+    { name = "django-stubs", extras = ["compatible-mypy"], specifier = "~=5.1" },
+    { name = "ipykernel", specifier = "~=6.27" },
+    { name = "mkdocs", specifier = "~=1.6" },
+    { name = "mkdocs-material", specifier = "~=9.5" },
+    { name = "mkdocstrings", extras = ["python"], specifier = "~=0.26" },
+    { name = "mypy", specifier = "~=1.11" },
+    { name = "ruff", specifier = "~=0.6" },
+]
+test = [
+    { name = "coverage", specifier = "~=7.3" },
+    { name = "django-coverage-plugin", specifier = "~=3.1" },
+    { name = "factory-boy", specifier = "~=3.3" },
+    { name = "faker", specifier = ">=30.3,<37.0" },
+    { name = "nox", specifier = ">=2024.10.9,<2025.3.0" },
+    { name = "pytest", specifier = "~=8.0" },
+    { name = "pytest-cov", specifier = ">=5,<7" },
+    { name = "pytest-django", specifier = "~=4.9" },
+    { name = "pytest-sugar", specifier = "~=1.0" },
+    { name = "pytest-xdist", specifier = "~=3.6" },
+]
 
 [[package]]
 name = "django-stubs"


### PR DESCRIPTION
Use `dependency-groups` and `tool.uv.default-groups` to manage local development dependencies instead of `project.optional-dependencies`.